### PR TITLE
BREAKING CHANGE: Reworks the `env` package API entirely.

### DIFF
--- a/.idx/airules.md
+++ b/.idx/airules.md
@@ -65,7 +65,7 @@ The AI context generation mechanism (e.g., IDX AI feature, or `./contextvibes de
 
 *   **Project Description:**
     *   This is a Go utility library (`dui-go`) designed to provide foundational components for building Go-based services, particularly those interacting with Google Cloud Platform.
-    *   It offers packages for common tasks such as authentication token management, caching, environment variable handling, structured error types, Firestore-backed key-value stores, and structured logging for Cloud Logging.
+    *   It offers packages for common tasks such as authentication token management, caching, **type-safe loading of environment variables into structs via tags (`env` package)**, structured error types, Firestore-backed key-value stores, and structured logging for Cloud Logging.
 
 *   **Tech Stack:**
     *   **Language:** Go (version specified in `.idx/dev.nix`, e.g., `pkgs.go_1_24`).
@@ -76,7 +76,7 @@ The AI context generation mechanism (e.g., IDX AI feature, or `./contextvibes de
         *   Firebase Studio (formerly Project IDX).
         *   Nix (`.idx/dev.nix` defines base tools like Go version, git, gcloud, `gopls`, `delve`, and VSCode extensions like `golang.go`).
         *   **`contextvibes` CLI:** Used for workflow automation.
-            *   **Installation:** `GOBIN=$(pwd)/bin go install github.com/contextvibes/cli/cmd/contextvibes@v0.0.5` (Installs to `./bin/`, run as `./bin/contextvibes` or ensure `./bin` is in PATH).
+            *   **Installation:** `GOBIN=/home/user/dui-go/bin go install github.com/contextvibes/cli/cmd/contextvibes@v0.0.5` (Installs to `./bin/`, run as `./bin/contextvibes` or ensure `./bin` is in PATH).
             *   **Usage:** Commands like `./bin/contextvibes kickoff`, `./bin/contextvibes commit`, `./bin/contextvibes test`, `./bin/contextvibes format`, etc. (See `./bin/contextvibes --help`)
     *   **Testing:** Go standard testing (`testing` package, `_test.go` files), invoked via `./bin/contextvibes test` or `go test ./...`. Encourage table-driven tests where appropriate.
 
@@ -104,7 +104,7 @@ The AI context generation mechanism (e.g., IDX AI feature, or `./contextvibes de
 
 *   **Security Notes:**
     *   **Auth:** Relies on GCP Application Default Credentials (ADC).
-    *   **Input Validation:** Library expects consumers to perform validation of inputs before calling library functions.
+    *   **Input Validation:** Library expects consumers to perform validation of inputs before calling library functions. The `env` package handles basic required checks via tags.
     *   **Error Handling:** Packages return errors; the `errors` package provides structure. Avoid leaking sensitive information in error messages.
     *   **Dependencies:** Keep Go modules updated (`go list -m -u all`). Suggest running this periodically.
     *   **AI-Generated Code:** All AI-generated code suggestions must be critically reviewed by the developer for correctness and security implications.
@@ -128,6 +128,7 @@ The AI context generation mechanism (e.g., IDX AI feature, or `./contextvibes de
     *   When providing code modifications, clearly state the filename and provide sufficient context. For significant changes or new files, provide the complete file content.
     *   For generating new Go files or multi-line content, use `cat <<EOF > path/to/filename.go ... EOF` within a `bash` block.
     *   Utilize the standard `log/slog` package for any logging. If context suggests Cloud Logging, recommend using the `logging/cloudlogging` handler from this library.
+    *   **Configuration Loading:** When generating code that requires loading configuration from environment variables, **prefer using the `env.Process` function** with a tagged struct pointer over manual `os.Getenv` calls.
     *   **Error Handling:**
         *   Always check returned errors: `if err != nil { ... }`.
         *   Wrap errors with contextual information using `fmt.Errorf("action failed: %w", err)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+## [0.0.2] - 2025-05-07
+
+### Changed
+*   **BREAKING CHANGE:** Refactored the `env` package for type-safe environment variable loading into structs.
+    *   Removed the previous API based on `env.EnvVar` slices and the `env.EnvLoader` which returned `map[string]string`.
+    *   Introduced the `env.Process(spec any)` function which populates the fields of a given struct pointer based on environment variables.
+    *   Configuration is now managed via struct tags:
+        *   `env:"VAR_NAME"`: Specifies the environment variable name (defaults to uppercase field name).
+        *   `envDefault:"value"`: Provides a default string value if the environment variable is not set or empty.
+        *   `envRequired:"true"`: Marks the environment variable as mandatory.
+    *   Supported field types for parsing: `string`, `int`, `int64`, `bool`.
+
 ## [0.0.1] - 2025-05-07
 
 ### Added
-- Initial public release of the `dui-go` utility library.
-- Core packages:
-    - `authentication`: Token management.
-    - `cache`: In-memory caching interface and implementation.
-    - `env`: Environment variable loading and validation.
-    - `errors`: Structured API error types.
-    - `firestore`: Firestore-backed key-value store.
-    - `logging/cloudlogging`: Google Cloud Logging `slog` handler and middleware.
-    - `store`: Generic key-value store interface with Firestore implementation.
+*   Initial public release of the `dui-go` utility library.
+*   Core packages:
+    *   `authentication`: Token management.
+    *   `cache`: In-memory caching interface and implementation.
+    *   `env`: Environment variable loading and validation (map-based).
+    *   `errors`: Structured API error types.
+    *   `firestore`: Firestore-backed key-value store.
+    *   `logging/cloudlogging`: Google Cloud Logging `slog` handler and middleware.
+    *   `store`: Generic key-value store interface with Firestore implementation.
 *   **Internal Testing Utilities:**
     *   `internal/testutil`: Created mock implementations for `cache.Cache` and `firestore.KV` to support testing.
 *   **Project Foundation:**
@@ -29,11 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-<!--
-Link Definitions - Add the new one when tagging a new version.
-The first entry (Unreleased) would typically look like this:
-## [Unreleased]
-
-[Unreleased]: https://github.com/duizendstra/dui-go/compare/v0.0.1...HEAD
--->
+<!-- Link Definitions -->
+[Unreleased]: https://github.com/duizendstra/dui-go/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/duizendstra/dui-go/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/duizendstra/dui-go/releases/tag/v0.0.1

--- a/README.md
+++ b/README.md
@@ -28,13 +28,53 @@ This package offers a generic `Cache` interface for in-memory and external cachi
 
 ### Env (`github.com/duizendstra/dui-go/env`)
 
-This package simplifies environment variable handling by providing a structured way to load and validate them.
+This package simplifies loading environment variables into Go structs in a type-safe manner. It uses reflection and struct tags for configuration, avoiding external dependencies.
 
 **Key Features:**
 
-*   **`EnvVar` struct:** Defines the configuration for an environment variable, including its key, whether it's mandatory, a default value, and an optional validation function.
-*   **`EnvLoader`:** Reads a list of `EnvVar` configurations, retrieves their values from the environment, applies defaults, and performs validation.
-*   **Error reporting:** Returns errors if mandatory variables are missing or validation fails.
+*   **`Process(spec interface{})` function:** Populates the fields of a struct pointer (`spec`) based on environment variables.
+*   **Tag-Based Configuration:**
+    *   `env:"VAR_NAME"`: Specifies the environment variable name (defaults to uppercase field name).
+    *   `envDefault:"value"`: Provides a default value if the environment variable is not set or empty.
+    *   `envRequired:"true"`: Marks the variable as mandatory; returns an error if missing or empty.
+*   **Type Safety:** Loads values directly into struct fields with their defined types.
+*   **Supported Types:** Currently handles `string`, `int`, `int64`, and `bool`.
+*   **Error Reporting:** Returns errors for missing required variables, parsing issues, or unsupported types.
+
+**Example Usage:**
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/duizendstra/dui-go/env"
+)
+
+type Config struct {
+	Host      string `env:"APP_HOST" envDefault:"localhost"`
+	Port      int    `env:"APP_PORT" envRequired:"true"`
+	DebugMode bool   `env:"DEBUG_MODE" envDefault:"false"`
+}
+
+func main() {
+	// Example: Set a required environment variable
+	os.Setenv("APP_PORT", "8080")
+	defer os.Unsetenv("APP_PORT")
+
+	var cfg Config
+	err := env.Process(&cfg)
+	if err != nil {
+		log.Fatalf("Error loading config: %v", err)
+	}
+
+	fmt.Printf("Host: %s, Port: %d, Debug: %t\n", cfg.Host, cfg.Port, cfg.DebugMode)
+	// Output: Host: localhost, Port: 8080, Debug: false
+}
+```
 
 ### Errors (`github.com/duizendstra/dui-go/errors`)
 

--- a/env/doc.go
+++ b/env/doc.go
@@ -1,20 +1,19 @@
-// Package env provides functionality for loading and validating environment variables.
-// It allows you to define a list of expected environment variables, specifying whether
-// they are mandatory, have a default value, or require validation.
+// Package env provides utilities for loading environment variables
+// directly into Go structs. Configuration is managed via struct tags.
 //
-// Typical usage:
+// It aims to simplify application configuration by providing a type-safe
+// way to consume environment variables with support for defaults and
+// required fields, without requiring external dependencies.
 //
-//	loader := env.NewEnvLoader()
-//	vars := []env.EnvVar{
-//	  {Key: "API_KEY", Mandatory: true},
-//	  {Key: "PORT", Mandatory: false, DefaultValue: "8080"},
-//	}
-//	envMap, err := loader.LoadEnv(vars) // Note: ctx parameter removed
-//	if err != nil {
-//	  // handle error (e.g., missing mandatory variable)
-//	}
+// Currently supported field types for struct population are:
+// string, int, int64, and bool.
 //
-// The EnvLoader returns errors if mandatory variables are missing or validation fails.
-// Using this approach simplifies startup configuration and ensures that your application
-// clearly reports configuration issues through returned errors.
+// Struct tags used for configuration:
+//   - `env:"ENV_VAR_NAME"`: Specifies the environment variable name.
+//     Defaults to the uppercase field name if omitted or empty.
+//   - `envDefault:"value"`: Provides a default string value if the
+//     environment variable is not set or is empty. This string will be
+//     parsed to the field's type.
+//   - `envRequired:"true"`: Marks the environment variable as mandatory.
+//     An error is returned if it's not set or is an empty string.
 package env

--- a/env/env.go
+++ b/env/env.go
@@ -3,57 +3,125 @@ package env
 import (
 	"fmt"
 	"os"
+	"reflect"
+	"strconv"
+	"strings"
 )
 
-// EnvVar represents a configuration for a single environment variable.
-// - Key: the variable name.
-// - Mandatory: if true, an error is returned if not set.
-// - DefaultValue: used if optional and not set.
-// - Validation: optional function to validate the value.
-type EnvVar struct {
-	Key          string
-	Mandatory    bool
-	DefaultValue string
-	Validation   func(string) bool
-}
-
-// EnvLoader reads and validates environment variables. It no longer logs, only returns errors.
-type EnvLoader struct{}
-
-// NewEnvLoader constructs an EnvLoader. It does not require a logger.
-func NewEnvLoader() *EnvLoader {
-	return &EnvLoader{}
-}
-
-// handleEnvError returns an error about missing or invalid environment variables.
-func (el *EnvLoader) handleEnvError(key string, message string) error {
-	return fmt.Errorf(message, key)
-}
-
-// LoadEnv reads, validates, and returns environment variables based on the given configuration.
-// Returns an error if a mandatory variable is missing or validation fails.
-func (el *EnvLoader) LoadEnv(vars []EnvVar) (map[string]string, error) {
-	envMap := make(map[string]string)
-
-	for _, v := range vars {
-		value, exists := os.LookupEnv(v.Key)
-
-		if !exists && v.Mandatory {
-			return nil, el.handleEnvError(v.Key,
-				"Mandatory environment variable is missing: %s")
-		}
-
-		if !exists {
-			value = v.DefaultValue
-		}
-
-		if v.Validation != nil && !v.Validation(value) {
-			return nil, el.handleEnvError(v.Key,
-				"Validation failed for environment variable: %s")
-		}
-
-		envMap[v.Key] = value
+// Process populates the fields of the struct pointed to by 'spec'
+// using environment variables.
+//
+// Fields in the struct should be tagged with:
+//   - `env:"ENV_VAR_NAME"`: Specifies the environment variable name.
+//     If not provided, the uppercase field name is used. An empty tag (`env:""`)
+//     also defaults to the uppercase field name.
+//   - `envDefault:"value"`: Specifies the default value to use if the
+//     environment variable is not set or is an empty string.
+//     The default value is treated as a string and will be parsed
+//     according to the field's type.
+//   - `envRequired:"true"`: Specifies that the environment variable
+//     must be set and non-empty. An error is returned if a required
+//     variable is missing or empty. If a field is required, `envDefault`
+//     is effectively ignored for that variable (as it *must* be provided from the environment).
+//
+// Supported field types are: string, int, int64, bool.
+// Other types will result in an error during processing if a value needs to be set for them.
+//
+// Order of precedence for a field's value:
+// 1. Environment variable (if set and non-empty).
+// 2. Default value (if env var is not set or empty, and field is not required).
+// 3. Go zero value (if env var not set or empty, no default, and not required).
+//
+// An empty string from an environment variable is considered "empty" for
+// the purpose of 'required' checks. For non-string types, an empty environment
+// variable (even if set) will cause parsing to use the default value if available,
+// or error if required and no non-empty value can be determined. For string types,
+// an empty string from the environment is a valid value.
+func Process(spec any) error {
+	val := reflect.ValueOf(spec)
+	if val.Kind() != reflect.Ptr {
+		return fmt.Errorf("env: spec must be a pointer to a struct, got %T", spec)
+	}
+	if val.IsNil() {
+		return fmt.Errorf("env: spec cannot be a nil pointer")
+	}
+	s := val.Elem()
+	if s.Kind() != reflect.Struct {
+		return fmt.Errorf("env: spec must be a pointer to a struct, got pointer to %s", s.Kind())
 	}
 
-	return envMap, nil
+	typ := s.Type()
+	for i := 0; i < s.NumField(); i++ {
+		field := s.Field(i)
+		fieldType := typ.Field(i)
+
+		if !field.CanSet() {
+			continue // Skip unexported fields
+		}
+
+		envVarName := strings.ToUpper(fieldType.Name)
+		if tagName, ok := fieldType.Tag.Lookup("env"); ok && tagName != "" {
+			envVarName = tagName
+		}
+
+		defaultValueStr := fieldType.Tag.Get("envDefault")
+		required := fieldType.Tag.Get("envRequired") == "true"
+
+		envValueStr, envExists := os.LookupEnv(envVarName)
+
+		var valueToParse string
+		shouldParseAndSet := false
+
+		if required {
+			if !envExists || envValueStr == "" {
+				return fmt.Errorf("env: required environment variable %s is not set or is empty", envVarName)
+			}
+			valueToParse = envValueStr
+			shouldParseAndSet = true
+		} else { // Not required
+			if envExists && envValueStr != "" { // Env var is set and non-empty
+				valueToParse = envValueStr
+				shouldParseAndSet = true
+			} else if envExists && envValueStr == "" { // Env var is set but empty string
+				if field.Kind() == reflect.String { // For strings, empty is a valid value if not required
+					valueToParse = ""
+					shouldParseAndSet = true
+				} else if defaultValueStr != "" { // For non-strings, empty string from env, use default
+					valueToParse = defaultValueStr
+					shouldParseAndSet = true
+				}
+				// If non-string, empty from env, no default, not required: shouldParseAndSet remains false (use Go zero)
+			} else if !envExists && defaultValueStr != "" { // Env var not set, but default exists
+				valueToParse = defaultValueStr
+				shouldParseAndSet = true
+			}
+			// If !envExists, no default, not required: shouldParseAndSet remains false (use Go zero)
+		}
+
+		if !shouldParseAndSet {
+			continue // Leave field with its Go zero value
+		}
+
+		switch field.Kind() {
+		case reflect.String:
+			field.SetString(valueToParse)
+		case reflect.Int, reflect.Int64:
+			intValue, err := strconv.ParseInt(valueToParse, 0, field.Type().Bits())
+			if err != nil {
+				return fmt.Errorf("env: failed to parse int for %s (variable %s, value: '%s'): %w", fieldType.Name, envVarName, valueToParse, err)
+			}
+			field.SetInt(intValue)
+		case reflect.Bool:
+			boolValue, err := strconv.ParseBool(valueToParse)
+			if err != nil {
+				return fmt.Errorf("env: failed to parse bool for %s (variable %s, value: '%s'): %w", fieldType.Name, envVarName, valueToParse, err)
+			}
+			field.SetBool(boolValue)
+		default:
+			// Only error if we were actually trying to parse a value for an unsupported type.
+			// If shouldParseAndSet was false, we wouldn't reach here for this field.
+			return fmt.Errorf("env: unsupported type %s for field %s (variable %s)", field.Kind(), fieldType.Name, envVarName)
+		}
+	}
+	return nil
 }

--- a/env/env_test.go
+++ b/env/env_test.go
@@ -5,103 +5,423 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestLoadEnv(t *testing.T) {
-	loader := NewEnvLoader()
-
-	t.Setenv("MANDATORY_VAR", "mandatory_value")
-	t.Setenv("OPTIONAL_VAR", "optional_value")
-
-	// Define a validation function that only allows values that start with "valid"
-	validFunc := func(val string) bool {
-		return len(val) >= 5 && val[:5] == "valid"
-	}
-
-	vars := []EnvVar{
-		{Key: "MANDATORY_VAR", Mandatory: true},
-		{Key: "OPTIONAL_VAR", DefaultValue: "default_opt"},
-		{Key: "MISSING_OPTIONAL", DefaultValue: "default_missing"},
-		{Key: "VALIDATED_VAR", DefaultValue: "valid_value", Validation: validFunc},
-	}
-
-	t.Setenv("VALIDATED_VAR", "valid_data")
-
-	envMap, err := loader.LoadEnv(vars) // ctx removed
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Check mandatory var
-	if got := envMap["MANDATORY_VAR"]; got != "mandatory_value" {
-		t.Errorf("expected MANDATORY_VAR=mandatory_value, got %q", got)
-	}
-
-	// Check optional var
-	if got := envMap["OPTIONAL_VAR"]; got != "optional_value" {
-		t.Errorf("expected OPTIONAL_VAR=optional_value, got %q", got)
-	}
-
-	// Check missing optional var uses default
-	if got := envMap["MISSING_OPTIONAL"]; got != "default_missing" {
-		t.Errorf("expected MISSING_OPTIONAL=default_missing, got %q", got)
-	}
-
-	// Check validated var
-	if got := envMap["VALIDATED_VAR"]; got != "valid_data" {
-		t.Errorf("expected VALIDATED_VAR=valid_data, got %q", got)
-	}
-
-	// Test missing mandatory variable
-	os.Unsetenv("MANDATORY_VAR") // Unset for this specific sub-test
-	varsMissingMandatory := []EnvVar{
-		{Key: "MANDATORY_VAR", Mandatory: true},
-	}
-
-	_, err = loader.LoadEnv(varsMissingMandatory) // ctx removed
-	if err == nil {
-		t.Error("expected error for missing mandatory variable, got nil")
-	}
-	t.Setenv("MANDATORY_VAR", "mandatory_value") // Reset for subsequent tests if any in other files
-
-	// Test validation failure
-	t.Setenv("VALIDATED_VAR", "invalid_value") // does not start with "valid"
-	varsValidationFail := []EnvVar{
-		{Key: "VALIDATED_VAR", DefaultValue: "valid_value", Validation: validFunc},
-	}
-
-	_, err = loader.LoadEnv(varsValidationFail) // ctx removed
-	if err == nil {
-		t.Error("expected error for invalid VALIDATED_VAR value, got nil")
-	} else {
-		assert.ErrorContains(t, err, "Validation failed for environment variable: VALIDATED_VAR")
-	}
-	t.Setenv("VALIDATED_VAR", "valid_data") // Reset for subsequent tests
+type testConfig struct {
+	Name           string `env:"TEST_NAME" envDefault:"DefaultName"`
+	Port           int    `env:"TEST_PORT" envRequired:"true"`
+	Timeout        int64  `env:"TEST_TIMEOUT" envDefault:"5000"`
+	Enabled        bool   `env:"TEST_ENABLED" envDefault:"true"` // Default "true" string for bool
+	AutoStart      bool   `env:"AUTO_START" envDefault:"false"`// Default "false" string for bool
+	NonTagged      string // Should look for NONTAGGED
+	MissingVar     string `env:"MISSING_VAR" envDefault:"DefaultMissing"`
+	EmptyVarSet    string `env:"EMPTY_VAR_SET"` // Set to "" explicitly, no default
+	EmptyVarDefault string `env:"EMPTY_VAR_DEFAULT" envDefault:"DefaultForEmpty"` // Not set, or set to "", should use default
+	NotSetInt      int    `env:"NOT_SET_INT"`   // Expect Go zero value
+	NotSetBool     bool   `env:"NOT_SET_BOOL"`  // Expect Go zero value
+	EmptyTagField  string `env:"" envDefault:"EmptyTagDefault"` // Uppercase field name: EMPTYTAGFIELD
 }
 
-func TestLoadEnv_NoVariables(t *testing.T) {
-	loader := NewEnvLoader()
+type requiredOnlyConfig struct {
+	MustExist    string `env:"MUST_EXIST" envRequired:"true"`
+	MustExistToo int    `env:"MUST_EXIST_TOO" envRequired:"true"`
+}
 
-	envMap, err := loader.LoadEnv(nil) // ctx removed
-	if err != nil {
-		t.Fatalf("expected no error with no vars, got %v", err)
+type badTypeConfig struct {
+	BadField float32 `env:"BAD_FIELD"` // float32 is unsupported
+}
+
+// setupEnvVars sets environment variables and returns a cleanup function.
+func setupEnvVars(t *testing.T, vars map[string]string) func() {
+	t.Helper()
+	originalVars := make(map[string]struct {
+		value  string
+		exists bool
+	})
+
+	for k, v := range vars {
+		originalValue, exists := os.LookupEnv(k)
+		originalVars[k] = struct {
+			value  string
+			exists bool
+		}{originalValue, exists}
+		err := os.Setenv(k, v)
+		require.NoError(t, err)
 	}
-	if len(envMap) != 0 {
-		t.Errorf("expected empty env map, got %d entries", len(envMap))
+
+	return func() {
+		for k := range vars { // Iterate over the keys that were originally in 'vars' to restore them
+			original := originalVars[k]
+			if original.exists {
+				err := os.Setenv(k, original.value)
+				require.NoError(t, err)
+			} else {
+				err := os.Unsetenv(k)
+				require.NoError(t, err)
+			}
+		}
 	}
 }
 
-func TestLoadEnv_OptionalDefault(t *testing.T) {
-	loader := NewEnvLoader()
+func TestProcess_Success(t *testing.T) {
+	cleanup := setupEnvVars(t, map[string]string{
+		"TEST_NAME":    "ActualName",
+		"TEST_PORT":    "8080",
+		"TEST_TIMEOUT": "30",
+		"TEST_ENABLED": "false", // Override default
+		"AUTO_START":   "true",  // Override default
+		"NONTAGGED":    "NonTaggedValue",
+		"EMPTY_VAR_SET": "",      // Explicitly empty
+		"EMPTYTAGFIELD": "FromEnv",
+	})
+	defer cleanup()
 
-	vars := []EnvVar{
-		{Key: "NON_EXISTENT", DefaultValue: "default_value"},
+	var cfg testConfig
+	err := Process(&cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "ActualName", cfg.Name)
+	assert.Equal(t, 8080, cfg.Port)
+	assert.Equal(t, int64(30), cfg.Timeout)
+	assert.Equal(t, false, cfg.Enabled)
+	assert.Equal(t, true, cfg.AutoStart)
+	assert.Equal(t, "NonTaggedValue", cfg.NonTagged)
+	assert.Equal(t, "DefaultMissing", cfg.MissingVar) // Uses default as MISSING_VAR is not set
+	assert.Equal(t, "", cfg.EmptyVarSet)              // Explicit empty string from env
+	assert.Equal(t, "DefaultForEmpty", cfg.EmptyVarDefault) // Uses default as EMPTY_VAR_DEFAULT is not set
+	assert.Equal(t, 0, cfg.NotSetInt)                  // Go zero value
+	assert.Equal(t, false, cfg.NotSetBool)             // Go zero value
+	assert.Equal(t, "FromEnv", cfg.EmptyTagField)
+}
+
+func TestProcess_DefaultsAndZeroValues(t *testing.T) {
+	varsToManage := []string{
+		"TEST_NAME", "TEST_PORT", "TEST_TIMEOUT", "TEST_ENABLED", "AUTO_START",
+		"NONTAGGED", "MISSING_VAR", "EMPTY_VAR_SET", "EMPTY_VAR_DEFAULT",
+		"NOT_SET_INT", "NOT_SET_BOOL", "EMPTYTAGFIELD",
 	}
-	envMap, err := loader.LoadEnv(vars) // ctx removed
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	originalValues := make(map[string]struct{ v string; e bool })
+	for _, k := range varsToManage {
+		v, e := os.LookupEnv(k)
+		originalValues[k] = struct{ v string; e bool }{v, e}
+		if k != "TEST_PORT" { // TEST_PORT needs to be set for this specific test to pass Process
+			os.Unsetenv(k)
+		}
 	}
-	if got := envMap["NON_EXISTENT"]; got != "default_value" {
-		t.Errorf("expected NON_EXISTENT=default_value, got %q", got)
+	// Set the required TEST_PORT for this test
+	err := os.Setenv("TEST_PORT", "9090")
+	require.NoError(t, err)
+
+
+	defer func() {
+		for _, k := range varsToManage {
+			ov := originalValues[k]
+			if ov.e {
+				os.Setenv(k, ov.v)
+			} else {
+				os.Unsetenv(k)
+			}
+		}
+	}()
+
+
+	var cfg testConfig
+	err = Process(&cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, "DefaultName", cfg.Name)
+	assert.Equal(t, 9090, cfg.Port) // Set value
+	assert.Equal(t, int64(5000), cfg.Timeout)
+	assert.Equal(t, true, cfg.Enabled)
+	assert.Equal(t, false, cfg.AutoStart)
+	assert.Equal(t, "", cfg.NonTagged) // Go zero as it was unset
+	assert.Equal(t, "DefaultMissing", cfg.MissingVar)
+	assert.Equal(t, "", cfg.EmptyVarSet)
+	assert.Equal(t, "DefaultForEmpty", cfg.EmptyVarDefault)
+	assert.Equal(t, 0, cfg.NotSetInt)
+	assert.Equal(t, false, cfg.NotSetBool)
+	assert.Equal(t, "EmptyTagDefault", cfg.EmptyTagField)
+}
+
+func TestProcess_RequiredMissing(t *testing.T) {
+	t.Run("TEST_PORT required and not set", func(t *testing.T) {
+		// Explicitly manage TEST_PORT and any other var for testConfig for this subtest
+		originalTestPort, testPortExists := os.LookupEnv("TEST_PORT")
+		originalTestName, testNameExists := os.LookupEnv("TEST_NAME")
+
+		os.Unsetenv("TEST_PORT") // Ensure TEST_PORT is not set
+		// Set other vars if they influence testConfig beyond the required field
+		// For testConfig, TEST_NAME doesn't need to be set for this specific check, but good to control
+		os.Unsetenv("TEST_NAME")
+
+
+		defer func() {
+			if testPortExists {
+				os.Setenv("TEST_PORT", originalTestPort)
+			} else {
+				os.Unsetenv("TEST_PORT")
+			}
+			if testNameExists {
+				os.Setenv("TEST_NAME", originalTestName)
+			} else {
+				os.Unsetenv("TEST_NAME")
+			}
+		}()
+
+		var cfg testConfig
+		err := Process(&cfg)
+		require.Error(t, err, "Process should error because TEST_PORT is required but not set")
+		if err != nil { // Check for nil before accessing Error()
+			assert.Contains(t, err.Error(), "required environment variable TEST_PORT is not set or is empty")
+		}
+	})
+
+	t.Run("MUST_EXIST required and set to empty", func(t *testing.T) {
+		originalMustExist, mustExistExists := os.LookupEnv("MUST_EXIST")
+		originalMustExistToo, mustExistTooExists := os.LookupEnv("MUST_EXIST_TOO")
+
+		os.Setenv("MUST_EXIST", "")      // Set to empty, which is invalid for required
+		os.Setenv("MUST_EXIST_TOO", "123") // Set this required field to a valid value
+
+		defer func() {
+			if mustExistExists {
+				os.Setenv("MUST_EXIST", originalMustExist)
+			} else {
+				os.Unsetenv("MUST_EXIST")
+			}
+			if mustExistTooExists {
+				os.Setenv("MUST_EXIST_TOO", originalMustExistToo)
+			} else {
+				os.Unsetenv("MUST_EXIST_TOO")
+			}
+		}()
+
+		var cfg requiredOnlyConfig
+		err := Process(&cfg)
+		require.Error(t, err, "Process should error because MUST_EXIST is required but set to empty")
+		if err != nil {
+			assert.Contains(t, err.Error(), "required environment variable MUST_EXIST is not set or is empty")
+		}
+	})
+
+	t.Run("MUST_EXIST_TOO required and not set", func(t *testing.T) {
+		originalMustExist, mustExistExists := os.LookupEnv("MUST_EXIST")
+		originalMustExistToo, mustExistTooExists := os.LookupEnv("MUST_EXIST_TOO")
+
+		os.Setenv("MUST_EXIST", "ValidValue") // Set this required field to a valid value
+		os.Unsetenv("MUST_EXIST_TOO")       // Ensure this required field is not set
+
+		defer func() {
+			if mustExistExists {
+				os.Setenv("MUST_EXIST", originalMustExist)
+			} else {
+				os.Unsetenv("MUST_EXIST")
+			}
+			if mustExistTooExists {
+				os.Setenv("MUST_EXIST_TOO", originalMustExistToo)
+			} else {
+				os.Unsetenv("MUST_EXIST_TOO")
+			}
+		}()
+
+		var cfg requiredOnlyConfig
+		err := Process(&cfg)
+		require.Error(t, err, "Process should error because MUST_EXIST_TOO is required but not set")
+		if err != nil {
+			assert.Contains(t, err.Error(), "required environment variable MUST_EXIST_TOO is not set or is empty")
+		}
+	})
+}
+
+func TestProcess_ParseErrors(t *testing.T) {
+	tests := []struct {
+		name        string
+		envVars     map[string]string
+		expectedMsg string
+	}{
+		{
+			name: "int parse error",
+			envVars: map[string]string{"TEST_PORT": "not-an-int"},
+			expectedMsg: "failed to parse int for Port (variable TEST_PORT, value: 'not-an-int')",
+		},
+		{
+			name: "bool parse error",
+			envVars: map[string]string{"TEST_ENABLED": "not-a-bool"},
+			expectedMsg: "failed to parse bool for Enabled (variable TEST_ENABLED, value: 'not-a-bool')",
+		},
+		{
+			name: "int64 parse error",
+			envVars: map[string]string{"TEST_TIMEOUT": "not-int64"},
+			expectedMsg: "failed to parse int for Timeout (variable TEST_TIMEOUT, value: 'not-int64')",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Base valid values for required fields in testConfig
+			baseConfigVars := map[string]string{
+				"TEST_PORT": "0", // Required
+				// TEST_ENABLED and TEST_TIMEOUT have defaults, so not strictly needed here for Process to run
+			}
+			// Overlay test-specific vars
+			for k, v := range tt.envVars {
+				baseConfigVars[k] = v
+			}
+
+			cleanup := setupEnvVars(t, baseConfigVars)
+			defer cleanup()
+
+			var cfg testConfig
+			err := Process(&cfg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedMsg)
+		})
 	}
 }
+
+func TestProcess_UnsupportedType(t *testing.T) {
+	var cfg badTypeConfig // BadField is float32
+	// If BAD_FIELD is not set, Process should not error for this field
+	err := Process(&cfg)
+	require.NoError(t, err)
+
+	// If BAD_FIELD is set, then it should error during attempt to parse/set
+	cleanup := setupEnvVars(t, map[string]string{"BAD_FIELD": "1.23"})
+	defer cleanup()
+
+	err = Process(&cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported type float32 for field BadField")
+}
+
+func TestProcess_NotAPointer(t *testing.T) {
+	var cfg testConfig // Not a pointer
+	err := Process(cfg)
+	require.Error(t, err)
+	assert.Equal(t, "env: spec must be a pointer to a struct, got env.testConfig", err.Error())
+}
+
+func TestProcess_NilPointer(t *testing.T) {
+	var cfg *testConfig = nil // Nil pointer
+	err := Process(cfg)
+	require.Error(t, err)
+	assert.Equal(t, "env: spec cannot be a nil pointer", err.Error())
+}
+
+func TestProcess_PointerToNonStruct(t *testing.T) {
+	var i int
+	err := Process(&i) // Pointer to int
+	require.Error(t, err)
+	assert.Equal(t, "env: spec must be a pointer to a struct, got pointer to int", err.Error())
+}
+
+func TestProcess_EmptyEnvTagDefaultsToFieldName(t *testing.T) {
+	type Config struct {
+		MyField string `env:"" envDefault:"helloFromEmptyTag"`
+	}
+	var cfg Config
+
+	originalMyField, myFieldExists := os.LookupEnv("MYFIELD")
+	os.Unsetenv("MYFIELD") // Ensure MYFIELD is not set to test default
+	defer func() {
+		if myFieldExists {
+			os.Setenv("MYFIELD", originalMyField)
+		} else {
+			os.Unsetenv("MYFIELD")
+		}
+	}()
+
+	err := Process(&cfg)
+	require.NoError(t, err)
+	assert.Equal(t, "helloFromEmptyTag", cfg.MyField)
+
+	// Test when MYFIELD is set from env
+	cleanup := setupEnvVars(t, map[string]string{"MYFIELD": "worldFromEmptyTag"})
+	defer cleanup() // This will restore MYFIELD to its state before this setupEnvVars call
+	
+	err = Process(&cfg) // Re-process with the new env var
+	require.NoError(t, err)
+	assert.Equal(t, "worldFromEmptyTag", cfg.MyField)
+}
+
+func TestProcess_RequiredFieldIgnoresDefault(t *testing.T) {
+	type Config struct {
+		ImportantValue string `env:"IMPORTANT_VAL" envRequired:"true" envDefault:"shouldBeIgnored"`
+	}
+	var cfg Config
+
+	t.Run("required var missing", func(t *testing.T) {
+		originalImpVal, impValExists := os.LookupEnv("IMPORTANT_VAL")
+		os.Unsetenv("IMPORTANT_VAL")
+		defer func() {
+			if impValExists { os.Setenv("IMPORTANT_VAL", originalImpVal) } else { os.Unsetenv("IMPORTANT_VAL") }
+		}()
+
+		err := Process(&cfg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "required environment variable IMPORTANT_VAL is not set or is empty")
+	})
+
+	t.Run("required var set", func(t *testing.T) {
+		originalImpVal, impValExists := os.LookupEnv("IMPORTANT_VAL")
+		os.Setenv("IMPORTANT_VAL", "actualValueFromEnv")
+		defer func() {
+			if impValExists { os.Setenv("IMPORTANT_VAL", originalImpVal) } else { os.Unsetenv("IMPORTANT_VAL") }
+		}()
+		
+		err := Process(&cfg)
+		require.NoError(t, err)
+		assert.Equal(t, "actualValueFromEnv", cfg.ImportantValue)
+	})
+}
+
+func TestProcess_EmptyStringFromEnvForNonString(t *testing.T) {
+	type Config struct {
+		MyInt  int  `env:"MY_INT" envDefault:"123"`
+		MyBool bool `env:"MY_BOOL" envDefault:"true"`
+	}
+	var cfg Config
+
+	originalMyInt, myIntExists := os.LookupEnv("MY_INT")
+	originalMyBool, myBoolExists := os.LookupEnv("MY_BOOL")
+
+	os.Setenv("MY_INT", "")  // Set to empty
+	os.Setenv("MY_BOOL", "") // Set to empty
+	defer func() {
+		if myIntExists { os.Setenv("MY_INT", originalMyInt) } else { os.Unsetenv("MY_INT") }
+		if myBoolExists { os.Setenv("MY_BOOL", originalMyBool) } else { os.Unsetenv("MY_BOOL") }
+	}()
+
+	err := Process(&cfg)
+	require.NoError(t, err)
+	assert.Equal(t, 123, cfg.MyInt, "Expected default int value when env var is empty")
+	assert.Equal(t, true, cfg.MyBool, "Expected default bool value when env var is empty")
+}
+
+func TestProcess_UnexportedField(t *testing.T) {
+    type Config struct {
+        Exported   string `env:"EXPORTED_FIELD" envDefault:"exported"`
+        unexported string // No tags, unexported
+    }
+    var cfg Config
+    cfg.unexported = "initial" // Set initial value for unexported field
+
+    // Explicitly manage env vars for this test
+    originalExported, exportedExists := os.LookupEnv("EXPORTED_FIELD")
+    originalUnexportedEnv, unexportedEnvExists := os.LookupEnv("UNEXPORTEDFIELD") // Default name for unexported
+
+    os.Setenv("EXPORTED_FIELD", "from_env")
+    os.Setenv("UNEXPORTEDFIELD", "env_unexported") // This should not affect the unexported field because it's unexported
+
+    defer func() {
+        if exportedExists { os.Setenv("EXPORTED_FIELD", originalExported) } else { os.Unsetenv("EXPORTED_FIELD") }
+        if unexportedEnvExists { os.Setenv("UNEXPORTEDFIELD", originalUnexportedEnv) } else { os.Unsetenv("UNEXPORTEDFIELD") }
+    }()
+
+    err := Process(&cfg)
+    require.NoError(t, err)
+    assert.Equal(t, "from_env", cfg.Exported)
+    assert.Equal(t, "initial", cfg.unexported, "Unexported field should not be modified by Process")
+}
+

--- a/env/example_test.go
+++ b/env/example_test.go
@@ -1,36 +1,89 @@
-package env
+package env_test // Use _test to ensure it's a black-box test
 
 import (
 	"fmt"
+	"log"
 	"os"
+
+	"github.com/duizendstra/dui-go/env" // Adjust import path to your project
 )
 
-func ExampleEnvLoader_LoadEnv() {
-	// Set environment variables for mandatory fields so the example passes.
-	os.Setenv("API_KEY", "secret-api-key")
-	os.Setenv("DATABASE_DSN", "user:pass@tcp(localhost:3306)/dbname")
+type AppConfig struct {
+	Host        string `env:"APP_HOST" envDefault:"localhost"`
+	Port        int    `env:"APP_PORT" envRequired:"true"`
+	DebugMode   bool   `env:"APP_DEBUG_MODE" envDefault:"false"`
+	ServiceName string `env:"SERVICE_NAME"` // Will look for SERVICE_NAME (uppercase field name)
+	EmptyEnvVar string `env:"EMPTY_ENV_VAR"` // Env var set to empty, no default
+	NotSetInt   int    `env:"NOT_SET_INT"`   // Go zero value expected
+	NotSetBool  bool   `env:"NOT_SET_BOOL"`  // Go zero value expected
+}
 
-	// Define the list of environment variables to load.
-	vars := []EnvVar{
-		{Key: "API_KEY", Mandatory: true},                           // Mandatory
-		{Key: "DATABASE_DSN", Mandatory: true},                      // Mandatory
-		{Key: "PORT", Mandatory: false, DefaultValue: "8080"},       // Optional with default
-		{Key: "ENV", Mandatory: false, DefaultValue: "development"}, // Optional with default
-	}
+func ExampleProcess() {
+	// Set up environment variables for the example
+	os.Setenv("APP_PORT", "8080")
+	os.Setenv("SERVICE_NAME", "MyAwesomeService")
+	os.Setenv("APP_DEBUG_MODE", "true")
+	os.Setenv("EMPTY_ENV_VAR", "") // Explicitly set to empty
 
-	// Create an EnvLoader without a logger.
-	loader := NewEnvLoader()
+	// Clean up environment variables after the test
+	defer func() {
+		os.Unsetenv("APP_HOST") // ensure it is not set if test runner has it
+		os.Unsetenv("APP_PORT")
+		os.Unsetenv("SERVICE_NAME")
+		os.Unsetenv("APP_DEBUG_MODE")
+		os.Unsetenv("EMPTY_ENV_VAR")
+		os.Unsetenv("NOT_SET_INT")  // Ensure these are not set for the test
+		os.Unsetenv("NOT_SET_BOOL")
+	}()
 
-	// Load the environment variables based on the defined configuration.
-	envMap, err := loader.LoadEnv(vars) // Note: ctx parameter removed
+	var cfg AppConfig
+	err := env.Process(&cfg)
 	if err != nil {
-		fmt.Println("Error:", err)
-		return
+		log.Fatalf("Failed to process environment: %v", err)
 	}
 
-	// Print the successfully loaded environment variables.
-	fmt.Println("Loaded env:", envMap)
+	fmt.Printf("Host: %s\n", cfg.Host)
+	fmt.Printf("Port: %d\n", cfg.Port)
+	fmt.Printf("Debug Mode: %t\n", cfg.DebugMode)
+	fmt.Printf("Service Name: %s\n", cfg.ServiceName)
+	fmt.Printf("Empty Env Var: '%s'\n", cfg.EmptyEnvVar)
+	fmt.Printf("Not Set Int (Go zero value): %d\n", cfg.NotSetInt)
+	fmt.Printf("Not Set Bool (Go zero value): %t\n", cfg.NotSetBool)
 
 	// Output:
-	// Loaded env: map[API_KEY:secret-api-key DATABASE_DSN:user:pass@tcp(localhost:3306)/dbname ENV:development PORT:8080]
+	// Host: localhost
+	// Port: 8080
+	// Debug Mode: true
+	// Service Name: MyAwesomeService
+	// Empty Env Var: ''
+	// Not Set Int (Go zero value): 0
+	// Not Set Bool (Go zero value): false
+}
+
+func ExampleProcess_requiredMissing() {
+	// Ensure APP_REQUIRED_PORT is not set for this specific example run
+	originalVal, originalExists := os.LookupEnv("APP_REQUIRED_PORT")
+	os.Unsetenv("APP_REQUIRED_PORT")
+	defer func() {
+		if originalExists {
+			os.Setenv("APP_REQUIRED_PORT", originalVal)
+		} else {
+			os.Unsetenv("APP_REQUIRED_PORT")
+		}
+	}()
+
+	type Config struct {
+		RequiredPort int `env:"APP_REQUIRED_PORT" envRequired:"true"`
+	}
+
+	var cfg Config
+	err := env.Process(&cfg)
+	if err != nil {
+		fmt.Printf("Error: %v\n", err) // Output the error for demonstration
+	} else {
+		fmt.Println("No error, but expected one for missing required var.")
+	}
+
+	// Output:
+	// Error: env: required environment variable APP_REQUIRED_PORT is not set or is empty
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/duizendstra/dui-go
 
-go 1.24.2
+go 1.24.3
 
 require (
 	cloud.google.com/go/compute/metadata v0.6.0


### PR DESCRIPTION
Removes the previous map-based environment variable loading mechanism (`EnvLoader`, `EnvVar`, `LoadEnv` returning `map[string]string`). This approach lacked type safety and required manual type conversions at the call site.

Introduces `env.Process(spec any)`, which populates a given struct pointer using environment variables configured via struct tags (`env`, `envDefault`, `envRequired`). This provides a type-safe way to load configuration directly into application structs without adding external dependencies, using Go's standard library reflection (`reflect`) and string conversion (`strconv`) capabilities.

The new approach supports basic types (string, int, int64, bool), default values, and required field checks.

Updates associated documentation (README, package docs, AI rules) to reflect the new API and usage.